### PR TITLE
Downgrade publishing plugin from v0.21.0 to v0.20.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "1.9.22"
 
 dokka = "1.9.10"
-mavenPublish = "0.21.0"
+mavenPublish = "0.20.0"
 
 kotlinx-binaryCompatibilityValidator = "0.13.2"
 


### PR DESCRIPTION
This is done as two staging repositories was created without explanation