### PR TITLE
A hotfix for data loss affecting any cache with more than 7 elements

### DIFF
--- a/kache/src/commonMain/kotlin/com/mayakapps/kache/collection/MutableChainedScatterMap.kt
+++ b/kache/src/commonMain/kotlin/com/mayakapps/kache/collection/MutableChainedScatterMap.kt
@@ -69,8 +69,6 @@ internal class MutableChainedScatterMap<K, V>(
         val accessoryChain = if (accessOrder) insertionChain else accessChain
 
         initializeStorage(newCapacity)
-        accessChain?.initializeStorage(_capacity)
-        insertionChain?.initializeStorage(_capacity)
 
         val newKeys = keys
         val newValues = values

--- a/kache/src/commonTest/kotlin/com/mayakapps/kache/collection/ChainedScatterMapTest.kt
+++ b/kache/src/commonTest/kotlin/com/mayakapps/kache/collection/ChainedScatterMapTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 MayakaApps
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mayakapps.kache.collection
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChainedScatterMapTest {
+
+    @Test
+    fun retainElementsAfterInternalResize() {
+        val map = MutableChainedScatterMap<String, Int>(
+            // The least possible capacity is 7
+            initialCapacity = 7,
+            accessChain = MutableChain(initialCapacity = 0),
+        )
+
+        repeat(8) {
+            map["$it"] = it
+        }
+
+        assertEquals(8, map.size)
+        repeat(8) {
+            assertEquals(it, map["$it"])
+        }
+    }
+}


### PR DESCRIPTION
A premature re-initialization of chains used in `MutableChainedScatterMap` led to loss of older data when resizing the map. This PR removes this erroneous call.

A test was added for the situation but more tests or modifying existing tests are needed to avoid such mistakes.

Closes #173.