### PR TITLE
feat(file-kache): allow untransformed key length up to 65535

### DIFF
--- a/file-kache/src/commonMain/kotlin/com/mayakapps/kache/journal/Consts.kt
+++ b/file-kache/src/commonMain/kotlin/com/mayakapps/kache/journal/Consts.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 MayakaApps
+ * Copyright 2024 MayakaApps
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package com.mayakapps.kache.journal
 
 internal const val JOURNAL_MAGIC = "JOURNAL"
-internal const val JOURNAL_VERSION: Byte = 3
+internal const val JOURNAL_VERSION: Byte = 4
 
 internal const val JOURNAL_FILE = "journal"
 internal const val JOURNAL_FILE_TEMP = "$JOURNAL_FILE.tmp"

--- a/file-kache/src/commonMain/kotlin/com/mayakapps/kache/journal/JournalReader.kt
+++ b/file-kache/src/commonMain/kotlin/com/mayakapps/kache/journal/JournalReader.kt
@@ -62,10 +62,10 @@ internal class JournalReader(
             return null
         }
 
-        val key = source.readByteLengthUtf8()
+        val key = source.readUShortLengthUtf8()
 
         val transformedKey =
-            if (opcodeId == JournalEntry.CLEAN_WITH_TRANSFORMED_KEY) source.readByteLengthUtf8()
+            if (opcodeId == JournalEntry.CLEAN_WITH_TRANSFORMED_KEY) source.readUByteLengthUtf8()
             else null
 
         return JournalEntry(opcodeId, key, transformedKey)
@@ -75,8 +75,13 @@ internal class JournalReader(
         source.close()
     }
 
-    private fun BufferedSource.readByteLengthUtf8(): String {
+    private fun BufferedSource.readUByteLengthUtf8(): String {
         val length = readByte().toUByte().toLong()
+        return readUtf8(length)
+    }
+
+    private fun BufferedSource.readUShortLengthUtf8(): String {
+        val length = readShort().toUShort().toLong()
         return readUtf8(length)
     }
 }

--- a/file-kache/src/commonMain/kotlin/com/mayakapps/kache/journal/JournalWriter.kt
+++ b/file-kache/src/commonMain/kotlin/com/mayakapps/kache/journal/JournalWriter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 MayakaApps
+ * Copyright 2024 MayakaApps
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,12 +65,17 @@ internal class JournalWriter(
 
     private fun writeEntry(opcode: Byte, key: String, transformedKey: String? = null) {
         sink.writeByte(opcode.toInt())
-        sink.writeByteLengthUtf8(key)
-        if (transformedKey != null) sink.writeByteLengthUtf8(transformedKey)
+        sink.writeUShortLengthUtf8(key)
+        if (transformedKey != null) sink.writeUByteLengthUtf8(transformedKey)
     }
 
-    private fun BufferedSink.writeByteLengthUtf8(string: String) {
+    private fun BufferedSink.writeUByteLengthUtf8(string: String) {
         writeByte(string.length)
+        writeUtf8(string)
+    }
+
+    private fun BufferedSink.writeUShortLengthUtf8(string: String) {
+        writeShort(string.length)
         writeUtf8(string)
     }
 

--- a/file-kache/src/commonTest/kotlin/com/mayakapps/kache/journal/JournalReadTest.kt
+++ b/file-kache/src/commonTest/kotlin/com/mayakapps/kache/journal/JournalReadTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 MayakaApps
+ * Copyright 2024 MayakaApps
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,8 +128,8 @@ class JournalReadTest {
         private val tempJournalFile = directory.resolve(JOURNAL_FILE_TEMP)
         private val backupJournalFile = directory.resolve(JOURNAL_FILE_BACKUP)
 
-        private val keyOneBytes = byteArrayOf(KEY_1.length.toByte()) + KEY_1.encodeToByteArray()
-        private val keyTwoBytes = byteArrayOf(KEY_2.length.toByte()) + KEY_2.encodeToByteArray()
+        private val keyOneBytes = byteArrayOf(0x00, KEY_1.length.toByte()) + KEY_1.encodeToByteArray()
+        private val keyTwoBytes = byteArrayOf(0x00, KEY_2.length.toByte()) + KEY_2.encodeToByteArray()
 
         private val journalHeader =
             byteArrayOf(0x4A, 0x4F, 0x55, 0x52, 0x4E, 0x41, 0x4C, JOURNAL_VERSION, 0x00, 0x00, 0x00, 0x01, 0x00)

--- a/file-kache/src/commonTest/kotlin/com/mayakapps/kache/journal/JournalReaderTest.kt
+++ b/file-kache/src/commonTest/kotlin/com/mayakapps/kache/journal/JournalReaderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 MayakaApps
+ * Copyright 2024 MayakaApps
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ class JournalReaderTest {
         // Journal with incorrect version
         val journalWithIncorrectVersion = bufferOf(
             0x4A, 0x4F, 0x55, 0x52, 0x4E, 0x41, 0x4C, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
-            0x01, 0x07, 0x54, 0x65, 0x73, 0x74, 0x4B, 0x65, 0x79,
+            0x01, 0x00, 0x07, 0x54, 0x65, 0x73, 0x74, 0x4B, 0x65, 0x79,
         )
 
         assertFailsWith<JournalInvalidHeaderException> {
@@ -48,7 +48,7 @@ class JournalReaderTest {
         // Different cache version
         val journalWithDifferentCacheVersion = bufferOf(
             0x4A, 0x4F, 0x55, 0x52, 0x4E, 0x41, 0x4C, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00,
-            0x01, 0x07, 0x54, 0x65, 0x73, 0x74, 0x4B, 0x65, 0x79,
+            0x01, 0x00, 0x07, 0x54, 0x65, 0x73, 0x74, 0x4B, 0x65, 0x79,
         )
 
         assertFailsWith<JournalInvalidHeaderException> {
@@ -76,28 +76,28 @@ class JournalReaderTest {
 
         // Dirty operation
         val dirtyOperation = bufferOf(
-            JournalEntry.DIRTY, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
+            JournalEntry.DIRTY, 0x00, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
         )
         val dirtyOperationResult = JournalReader(dirtyOperation).use { it.readEntry() }
         assertEquals(JournalEntry.Dirty(KEY_1), dirtyOperationResult)
 
         // Clean operation
         val cleanOperation = bufferOf(
-            JournalEntry.CLEAN, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
+            JournalEntry.CLEAN, 0x00, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
         )
         val cleanOperationResult = JournalReader(cleanOperation).use { it.readEntry() }
         assertEquals(JournalEntry.Clean(KEY_1), cleanOperationResult)
 
         // Remove operation
         val removeOperation = bufferOf(
-            JournalEntry.REMOVE, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
+            JournalEntry.REMOVE, 0x00, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
         )
         val removeOperationResult = JournalReader(removeOperation).use { it.readEntry() }
         assertEquals(JournalEntry.Remove(KEY_1), removeOperationResult)
 
         // Invalid operation
         val invalidOperation = bufferOf(
-            (0xFE).toByte(), KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
+            (0xFE).toByte(), 0x00, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
         )
         assertFailsWith<JournalInvalidOpcodeException> {
             JournalReader(invalidOperation).use { it.readEntry() }
@@ -111,7 +111,7 @@ class JournalReaderTest {
 
         // Dirty operation with truncated key
         val dirtyOperationWithTruncatedKey = bufferOf(
-            JournalEntry.DIRTY, KEY_1.length.toByte(), *KEY_1.first().toString().encodeToByteArray(),
+            JournalEntry.DIRTY, 0x00, KEY_1.length.toByte(), *KEY_1.first().toString().encodeToByteArray(),
         )
         assertFailsWith<EOFException> {
             JournalReader(dirtyOperationWithTruncatedKey).use { it.readEntry() }

--- a/file-kache/src/commonTest/kotlin/com/mayakapps/kache/journal/JournalWriterTest.kt
+++ b/file-kache/src/commonTest/kotlin/com/mayakapps/kache/journal/JournalWriterTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 MayakaApps
+ * Copyright 2024 MayakaApps
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class JournalWriterTest {
     @Test
     fun writeDirty() {
         val bytes = byteArrayOf(
-            JournalEntry.DIRTY, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
+            JournalEntry.DIRTY, 0x00, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
         )
 
         val buffer = Buffer()
@@ -47,7 +47,7 @@ class JournalWriterTest {
     @Test
     fun writeClean() {
         val bytes = byteArrayOf(
-            JournalEntry.CLEAN, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
+            JournalEntry.CLEAN, 0x00, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
         )
 
         val buffer = Buffer()
@@ -58,7 +58,7 @@ class JournalWriterTest {
     @Test
     fun writeRemove() {
         val bytes = byteArrayOf(
-            JournalEntry.REMOVE, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
+            JournalEntry.REMOVE, 0x00, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
         )
 
         val buffer = Buffer()
@@ -69,9 +69,9 @@ class JournalWriterTest {
     @Test
     fun writeAll() {
         val bytes = byteArrayOf(
-            JournalEntry.CLEAN_WITH_TRANSFORMED_KEY, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
+            JournalEntry.CLEAN_WITH_TRANSFORMED_KEY, 0x00, KEY_1.length.toByte(), *KEY_1.encodeToByteArray(),
             KEY_2.length.toByte(), *KEY_2.encodeToByteArray(),
-            JournalEntry.DIRTY, KEY_2.length.toByte(), *KEY_2.encodeToByteArray(),
+            JournalEntry.DIRTY, 0x00, KEY_2.length.toByte(), *KEY_2.encodeToByteArray(),
         )
 
         val buffer = Buffer()


### PR DESCRIPTION
- This limitation was imposed in v2.1.0-beta01.
- This also updates journal version to 4.

Signed-off-by: Mohamed Darwish <msdarwish@mayakapps.com>
