### PR TITLE
Fix Crash related to LRU with expiration time

### DIFF
--- a/kache/src/commonMain/kotlin/com/mayakapps/kache/collection/Chain.kt
+++ b/kache/src/commonMain/kotlin/com/mayakapps/kache/collection/Chain.kt
@@ -86,6 +86,7 @@ internal open class MutableChain(initialCapacity: Int) : Chain() {
         val oldHead = head
         val oldNext = next
         val oldExtras = getExtras()
+        val oldTail = tail
 
         initializeStorage(newCapacity)
         val newExtras = getExtras()
@@ -97,22 +98,22 @@ internal open class MutableChain(initialCapacity: Int) : Chain() {
         }
 
         head = newIndices[oldHead]
-        tail = newIndices[tail]
+        tail = newIndices[oldTail]
 
         var newPrevIndex = -1
         var newIndex = newIndices[oldHead]
 
         iterateChain(oldHead, oldNext) { oldIndex ->
             val oldNextIndex = oldNext[oldIndex]
-            val newNextIndex = newIndices[oldNextIndex]
+            val newNextIndex = if (oldNextIndex >= 0) { newIndices[oldNextIndex] } else -1
 
             next[newIndex] = newNextIndex
             prev[newIndex] = newPrevIndex
 
+            newExtras?.set(newIndex, oldExtras?.get(oldIndex))
+
             newPrevIndex = newIndex
             newIndex = newNextIndex
-
-            newExtras?.set(newIndex, oldExtras?.get(oldIndex))
         }
     }
 

--- a/kache/src/commonTest/kotlin/com/mayakapps/kache/InMemoryKacheTest.kt
+++ b/kache/src/commonTest/kotlin/com/mayakapps/kache/InMemoryKacheTest.kt
@@ -508,7 +508,7 @@ class InMemoryKacheTest {
     }
 
     @Test
-    fun trimToSizeCrashes() = runTest {
+    fun autoResizeOnAddThenTrim() = runTest {
         val removalLogger = EntryRemovalLogger<String, Int>()
 
         // LRU

--- a/kache/src/commonTest/kotlin/com/mayakapps/kache/TestUtils.kt
+++ b/kache/src/commonTest/kotlin/com/mayakapps/kache/TestUtils.kt
@@ -49,6 +49,13 @@ internal suspend fun InMemoryKache<String, Int>.putFourElementsWithAccess() {
     get(KEY_2)
 }
 
+/**
+ * Puts 8 elements into the kache and gets 24 of them. This way the state of the kache is as follows:
+ * - The least-recently-used element is [KEY_3] with [VAL_3]
+ * - The most-recently-used element is [KEY_5] with [VAL_5]
+ * - The first-in element is [KEY_1] with [VAL_1]
+ * - The last-in element is [KEY_8] with [VAL_8]
+ */
 internal suspend fun InMemoryKache<String, Int>.putEightElementsWithAccess() {
     put(KEY_1, VAL_1)
     put(KEY_2, VAL_2)

--- a/kache/src/commonTest/kotlin/com/mayakapps/kache/TestUtils.kt
+++ b/kache/src/commonTest/kotlin/com/mayakapps/kache/TestUtils.kt
@@ -49,6 +49,21 @@ internal suspend fun InMemoryKache<String, Int>.putFourElementsWithAccess() {
     get(KEY_2)
 }
 
+internal suspend fun InMemoryKache<String, Int>.putEightElementsWithAccess() {
+    put(KEY_1, VAL_1)
+    put(KEY_2, VAL_2)
+    put(KEY_3, VAL_3)
+    put(KEY_4, VAL_4)
+    put(KEY_5, VAL_5)
+    put(KEY_6, VAL_6)
+    put(KEY_7, VAL_7)
+    put(KEY_8, VAL_8)
+    get(KEY_1)
+    get(KEY_2)
+    get(KEY_4)
+    get(KEY_5)
+}
+
 internal class EntryRemovalLogger<K, V> {
     private val removedEntries = mutableListOf<Event<K, V>>()
 
@@ -84,3 +99,9 @@ internal const val KEY_4 = "four"
 internal const val VAL_4 = 4
 internal const val KEY_5 = "five"
 internal const val VAL_5 = 5
+internal const val KEY_6 = "six"
+internal const val VAL_6 = 6
+internal const val KEY_7 = "seven"
+internal const val VAL_7 = 7
+internal const val KEY_8 = "eight"
+internal const val VAL_8 = 8


### PR DESCRIPTION
This MR is related to the bug discussed here: https://github.com/MayakaApps/Kache/issues/249

A test was added to reproduce the crash, and then the fix was applied. 

Note: This failure was reproducible only when the cache strategy was LRU and there was an expireAfterWriteDuration set. The fix was to move the order of some of the logic around to store the old tail when resizing, adding some checks on index when iterating the chain, and updating the extras before advancing the index.