### PR TITLE
Wasm Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # Gradle
 #
-
+local.properties
 .gradle/
 **/build/
 !**/src/**/build/

--- a/kache/build.gradle.kts
+++ b/kache/build.gradle.kts
@@ -1,3 +1,6 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -26,9 +29,14 @@ kotlin {
         }
     }
 
-    // Still experimental - blocked by coroutines
-    // wasmJs()
-    // wasmWasi()
+    wasmJs {
+        browser()
+        nodejs()
+    }
+
+    wasmWasi {
+        nodejs()
+    }
 
     macosX64()
     macosArm64()


### PR DESCRIPTION
Adds wasm support for the core module.  
You need to update the publishing btw as sonatype has been shutdown.

Fixes https://github.com/MayakaApps/Kache/issues/331