### PR TITLE
Fix InMemoryKache::getOrPut race condition in high concurrency

### DIFF
--- a/kache/src/commonMain/kotlin/com/mayakapps/kache/InMemoryKache.kt
+++ b/kache/src/commonMain/kotlin/com/mayakapps/kache/InMemoryKache.kt
@@ -164,14 +164,15 @@ public class InMemoryKache<K : Any, V : Any> internal constructor(
     override suspend fun getOrPut(key: K, creationFunction: suspend (key: K) -> V?): V? {
         get(key)?.let { return it }
 
-        creationMutex.withLock {
+        val deferred = creationMutex.withLock {
             if (creationMap[key] == null && map[key] == null) {
-                @Suppress("DeferredResultUnused")
                 internalPutAsync(key, creationFunction)
+            } else {
+                creationMap[key]
             }
         }
 
-        return get(key)
+        return deferred?.let { getFromCreation(key, it) } ?: get(key)
     }
 
     override suspend fun put(key: K, creationFunction: suspend (key: K) -> V?): V? =

--- a/kache/src/commonTest/kotlin/com/mayakapps/kache/InMemoryKacheTest.kt
+++ b/kache/src/commonTest/kotlin/com/mayakapps/kache/InMemoryKacheTest.kt
@@ -686,4 +686,20 @@ class InMemoryKacheTest {
 
         assertEquals(0, kache.size)
     }
+
+    @Test
+    fun getOrPutHighConcurrency() = runTest {
+        // Regression test for https://github.com/MayakaApps/Kache/issues/239
+        // With more keys than maxSize, LRU eviction kicks in. In old code, a creation deferred
+        // could complete (on Dispatchers.Default) and get evicted between the creationMutex.withLock
+        // exit and the trailing get(key) call, returning null.
+        // Uses the real default creationScope (Dispatchers.Default) — testInMemoryKache overrides
+        // it to the single-threaded test dispatcher, which hides the race.
+        val kache = InMemoryKache<String, String>(maxSize = 100)
+
+        (0..20_000).forEach {
+            launch { assertNotNull(kache.getOrPut(it.toString()) { it.toString() }) }
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

Fixes #239.

`getOrPut` had a race condition under high concurrency: a creation deferred could complete and remove itself from `creationMap` (via its `finally` block) between the `creationMutex.withLock` exit and the trailing `get(key)` call. If the entry was also evicted by concurrent cache pressure in that window, `get(key)` would find nothing and return `null`.

The fix captures the deferred inside the lock (before it can remove itself from `creationMap`) and awaits it directly via `getFromCreation(key, deferred)`, returning the value from the deferred's completion state rather than re-looking it up through the map.

**Before:**
```kotlin
creationMutex.withLock {
    if (creationMap[key] == null && map[key] == null) {
        @Suppress("DeferredResultUnused")
        internalPutAsync(key, creationFunction)
    }
}
return get(key)  // deferred may have already completed and been evicted
```

**After:**
```kotlin
val deferred = creationMutex.withLock {
    if (creationMap[key] == null && map[key] == null) {
        internalPutAsync(key, creationFunction)
    } else {
        creationMap[key]  // capture existing deferred while holding the lock
    }
}
return deferred?.let { getFromCreation(key, it) } ?: get(key)
```

## Test plan

- Added `getOrPutHighConcurrency` regression test: launches 20,001 coroutines each calling `getOrPut` with a unique key against a `maxSize = 100` cache. The resulting LRU evictions reliably open the race window. The test uses `InMemoryKache` directly (not `testInMemoryKache`) so creation deferreds run on `Dispatchers.Default` real threads — `testInMemoryKache` overrides `creationScope` to the single-threaded test dispatcher which hides the race.
- Confirmed the test **fails** on the unfixed code and **passes** with the fix.
- Full `jvmTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)